### PR TITLE
Remove UdonSharp dependency

### DIFF
--- a/Packages/com.varneon.vudon.quick-menu/package.json
+++ b/Packages/com.varneon.vudon.quick-menu/package.json
@@ -11,12 +11,10 @@
   },
   "resolutionStrategy": "highestMinor",
   "dependencies": {
-    "com.vrchat.udonsharp": "1.1.7",
     "com.varneon.vudon.array-extensions": "0.3.0",
     "com.varneon.vudon.menus": "0.1.0-alpha.4"
   },
   "vpmDependencies": {
-    "com.vrchat.udonsharp": ">=1.1.7 <2.0.0",
     "com.varneon.vudon.array-extensions": ">=0.3.0",
     "com.varneon.vudon.menus": ">=0.1.0-alpha.3 <1.0.0"
   }


### PR DESCRIPTION
Closes #10

Quick Menu depends on Menus, which has Worlds SDK as a dependency